### PR TITLE
Set up automatic extraction of testnames

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,16 +48,6 @@ cd $OWD
 cp $FLUPRO/flutil/rfluka $FLUPRO/flutil/rfluka.orig
 patch $FLUPRO/flutil/rfluka $OWD/DAGMC/FluDAG/src/rfluka.patch 
 
-# Configure and make the gtest libs and unit tests
-# Make the gtest libraries so they are ready for the test phase
-# NOTE:  this will  be part of the fludag build soon
-
-# cd $OWD/DAGMC/gtest
-# mkdir `pwd`/lib
-# cd lib
-# cmake ../gtest-1.7.0
-# /.make
-
 # Compile the fludag source and link it to the fludag and dagmc libraries
 cd $OWD
 mkdir -p $OWD/DAGMC/FluDAG/bld

--- a/fludag.run-spec
+++ b/fludag.run-spec
@@ -1,5 +1,5 @@
 run_type = test
-inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gcc.SL6.scp, build.scp, build.SL6.scp
+inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.SL6.scp, build.scp, build.SL6.scp
 x86_64_Debian7_remote_pre_declare  = build.sh
 x86_64_Ubuntu12_remote_pre_declare = build.sh
 x86_64_Fedora18_remote_pre_declare = build.sh

--- a/generate_test_list.sh
+++ b/generate_test_list.sh
@@ -1,3 +1,7 @@
-#! /bin/bash
-echo "test_FlukaFuncs
-test_UnitNumber">tasklist.nmi
+set -x
+set -e
+DAGMC/FluDAG/bld/tests/fludag_unit_tests --gtest_list_tests  | python gen_test_list.py FLUDAG.
+DAGMC/FluDAG/bld/tests/fludag_unit_tests --gtest_list_tests  | python gen_test_list.py FLUDAG. > tasklist.nmi
+
+exit $?
+

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,3 +1,6 @@
-#! /bin/bash
-cd DAGMC/FluDAG/bld/test
-ctest -R ${_NMI_TASKNAME}
+set -x
+set -e
+cd DAGMC/FluDAG/bld/tests
+./fludag_unit_tests --gtest_filter=`echo ${_NMI_TASKNAME} | sed -e 's/__/\//g' | sed -e 's/FLUDAG.//g'`
+
+exit $?

--- a/submit.sh
+++ b/submit.sh
@@ -35,6 +35,12 @@ scp_file = $path/generate_test_list.sh
 ">$path/generate_test_list.scp
 
 echo \
+"method   = scp
+scp_file  = $path/gen_test_list.py
+recursive = true
+">$path/gen_test_list.py.scp
+
+echo \
 "method  = scp
 scp_file = $path/run-test.sh
 ">$path/run-test.scp


### PR DESCRIPTION
This version of the batlab scripts automates extracting testnames from the test executable and using the names to call each test individually.  It also fixes the problem I was having with the input file.

I tested this on my personal batlab login. the results are here:

http://submit-1.batlab.org/nmi/results/details?runID=244151
