### PR TITLE
Forgot the nightly run-spec

### DIFF
--- a/fludag_nightly.run-spec
+++ b/fludag_nightly.run-spec
@@ -1,5 +1,5 @@
 run_type = test
-inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gcc.SL6.scp, build.scp, build.SL6.scp 
+inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.SL6.scp, build.scp, build.SL6.scp
 x86_64_Debian7_remote_pre_declare  = build.sh
 x86_64_Ubuntu12_remote_pre_declare = build.sh
 x86_64_Fedora18_remote_pre_declare = build.sh
@@ -7,7 +7,7 @@ remote_declare = generate_test_list.sh
 remote_task    = run-test.sh
 platforms      = x86_64_Debian7, x86_64_Ubuntu12, x86_64_Fedora18
 project        = Fludag Nightly Unit Testing  
-description    = Run tests on all known good platforms
+description    = Nightly tests with automated test generation
 notify         = dagmcci@googlegroups.com
 cron_hour      = 14
 cron_minute    = 15


### PR DESCRIPTION
Needed to add new file to both fludag.run-spec and fludag_nightly.run-spec.  Without this change the new nightly build fails because it is missing a script.
