### PR TITLE
Filenames lower case; mod cron minute

### DIFF
--- a/fludag.run-spec
+++ b/fludag.run-spec
@@ -1,5 +1,5 @@
 run_type = test
-inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.SL6.scp, build.scp, build.sl6.scp
+inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.sl6.scp, build.scp, build.sl6.scp
 x86_64_Debian7_remote_pre_declare  = build.sh
 x86_64_Ubuntu12_remote_pre_declare = build.sh
 x86_64_Fedora18_remote_pre_declare = build.sh

--- a/fludag_nightly.run-spec
+++ b/fludag_nightly.run-spec
@@ -1,5 +1,5 @@
 run_type = test
-inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.SL6.scp, build.scp, build.sl6.scp
+inputs   =  fetch/hdf5.url, fetch/moab.url, fetch/dagmc.git, fluka.scp, run-test.scp, generate_test_list.scp, gen_test_list.py.scp, gcc.sl6.scp, build.scp, build.sl6.scp
 x86_64_Debian7_remote_pre_declare  = build.sh
 x86_64_Ubuntu12_remote_pre_declare = build.sh
 x86_64_Fedora18_remote_pre_declare = build.sh
@@ -8,7 +8,7 @@ remote_declare = generate_test_list.sh
 remote_task    = run-test.sh
 platforms      = x86_64_Debian7, x86_64_Ubuntu12, x86_64_Fedora18, x86_64_SL6
 project        = Fludag Nightly Unit Testing  
-description    = Nightly tests with automated test generation
+description    = Nightly tests: SL6, automated test generation
 notify         = dagmcci@googlegroups.com
 cron_hour      = 14
-cron_minute    = 15
+cron_minute    = 25


### PR DESCRIPTION
This fixes a mismatch in case (which did not, but would have eventually caused a nightly build error)
I've also changed the cron minute so we can see if the correct cron job is being done.  It looks like the nightly build on dagmcci is running old code, even though I deleted the existing job and started a new one.  

I am going to wait a day before launching a new nightly build, and then we can look at the cron minute, which should be 25 past the hour.
