### PR TITLE
Modify run-spec to copy DAGMC-CI files

### DIFF
--- a/fetch/dagmc-ci.git
+++ b/fetch/dagmc-ci.git
@@ -1,3 +1,3 @@
 method = git
 git_repo = git://github.com/svalinn/DAGMC-CI.git
-git_path = DAGMC-CI;cd DAGMC-CI; git checkout master
+git_path = DAGMC-CI;cd DAGMC-CI;git checkout master:cd ..;cp -R DAGMC-CI/* .


### PR DESCRIPTION
This needs to happen, was missed because testing runs already do this